### PR TITLE
Ported error_cleanup from autotest-client-tests to avocado

### DIFF
--- a/perf/error_cleanup.py
+++ b/perf/error_cleanup.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+
+from avocado import Test
+from avocado import main
+
+
+class error_cleanup(Test):
+    """
+    Raise an exception during cleanup()
+    """
+
+    def test(self):
+        pass
+
+    def cleanup(self):
+        self.NameError("test a bug in cleanup()")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Have ported error_cleanup from autotest-client-tests to avocado
