### PR TITLE
Ported error_cleanup from autotest-client-test to avocado

### DIFF
--- a/generic/error_cleanup.py
+++ b/generic/error_cleanup.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+
+from avocado import Test
+from avocado import main
+
+
+class error_cleanup(Test):
+    """
+    Raise an exception during tearDown()
+    """
+
+    def test(self):
+        pass
+
+    def tearDown(self):
+        self.error("Test a bug in tearDown()")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@apahim have placed error_cleanup in avocado-misc-test/generic
