### PR TITLE
Added ltp testcase which runs runltplite.sh as default

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Santhosh G <santhog4@linux.vnet.ibm.com>
+#
+# Based on code by Martin Bligh <mbligh@google.com>
+# copyright 2006 Google, Inc.
+# https://github.com/autotest/autotest-client-tests/tree/master/ltp
+
+
+import os
+import multiprocessing
+from avocado import Test
+from avocado import main
+from avocado.utils import process
+from avocado.utils import build
+from avocado.utils import git
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import distro
+
+
+class ltp(Test):
+    def setUp(self):
+        sm = SoftwareManager()
+        detected_distro = distro.detect()
+        deps = ['gcc', 'git', 'make', 'automake', 'autoconf']
+        for package in deps:
+            if package == 'git' and detected_distro.name == "SuSE":
+                package = 'git-core'
+            if not sm.check_installed(package) and not sm.install(package):
+                self.error(package + ' is needed for the test to be run')
+        git.get_repo('https://github.com/linux-test-project/ltp.git',
+                     destination_dir=self.srcdir)
+        os.chdir(self.srcdir)
+        build.make(self.srcdir, extra_args='autotools')
+        ltpbin_dir = os.path.join(self.srcdir, 'bin')
+        os.mkdir(ltpbin_dir)
+        process.system('./configure --prefix=%s' % ltpbin_dir)
+        build.make(self.srcdir, extra_args='-j %d' %
+                   multiprocessing.cpu_count())
+        build.make(self.srcdir, extra_args='install')
+
+    def test(self):
+        script = self.params.get('script', default='runltplite.sh')
+        args = self.params.get('args', default=' ')
+        if script == 'runltp':
+            logfile = os.path.join(self.logdir, 'ltp.log')
+            failcmdfile = os.path.join(self.logdir, 'failcmdfile')
+            skipfile = os.path.join(self.datadir, 'skipfile')
+            args2 = '-q -p -l %s -C %s -d %s -S %s' % (
+                logfile, failcmdfile, self.srcdir, skipfile)
+            args = args + ' ' + args2
+        ltpbin_dir = os.path.join(self.srcdir, 'bin')
+        cmd = os.path.join(ltpbin_dir, script) + ' ' + args
+        result = process.run(cmd, ignore_status=True)
+        failed_tests = []
+        for line in result.stdout.splitlines():
+            if set(('TFAIL', 'TBROK', 'TWARN')).intersection(line.split()):
+                test_name = line.strip().split(' ')[0]
+                if test_name not in failed_tests:
+                    failed_tests.append(test_name)
+
+        if failed_tests:
+            self.error("LTP tests failed: %s" % failed_tests)
+
+if __name__ == "__main__":
+    main()

--- a/generic/ltp.py.data/ltp.yaml
+++ b/generic/ltp.py.data/ltp.yaml
@@ -1,0 +1,58 @@
+setup:
+    general: !mux
+        default:
+            script: 'runltplite.sh'
+            args: ' '
+        runltp: !mux
+            script: 'runltp'
+            syscalls:
+                args: '-f syscalls'
+            mm:
+                args: '-f mm'
+            fs:
+                args: '-f fs'
+            fs_perms_simple:
+                args: '-f fs_perms_simple'
+            fsx:
+                args: '-f fsx'
+            dio:
+                args: '-f dio'
+            io:
+                args: '-f io'
+            ipc:
+                args: '-f ipc'
+            sched:
+                args: '-f sched'
+            math:
+                args: '-f math'
+            nptl:
+                args: '-f nptl'
+            pty:
+                args: '-f pty'
+            filecaps:
+                args: '-f filecaps'
+            cap_bounds:
+                args: '-f cap_bounds'
+            fs_bind:
+                args: '-f fs_bind'
+            fcntl-locktests:
+                args: '-f fcntl-locktests'
+            connectors:
+                args: '-f connectors'
+            aadmin_tools:
+                args: '-f admin_tools'
+            timers:
+                args: '-f timers'
+            power_management_tests:
+                args: '-f power_management_tests'
+            hyperthreading:
+                args: '-f hyperthreading'
+            containers:
+                args: '-f containers'
+            controllers:
+                args: '-f controllers'
+            hugetlb:
+                args: '-f hugetlb'
+            numa:
+                args: '-f numa'
+


### PR DESCRIPTION
This script runs runltplite.sh as a default one and it also runs runltp when run with multiplex option.
Currently the script fails when run with multiplex option since the below PR has to be merged in avocado.
PR: 
https://github.com/avocado-framework/avocado/pull/1241 
