### PR TITLE
Adding interbench test to avocado[V3]

### DIFF
--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+# Based on code by Brandon Philips
+#   copyright: 2006 IBM
+#   https://github.com/autotest/autotest-client-tests/tree/master/interbench
+
+import os
+
+from avocado import Test
+from avocado import main
+from avocado.utils import archive
+from avocado.utils import process
+from avocado.utils import build
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Interbench(Test):
+
+    """
+    Interbench is designed to measure the effect of changes in Linux kernel
+    design or system configuration changes such as cpu, I/O scheduler and
+    filesystem changes and options. With careful benchmarking, different
+    hardware can be compared
+    """
+
+    def setUp(self):
+        '''
+        Build interbench
+        Source:
+        http://ck.kolivas.org/apps/interbench/interbench-0.31.tar.bz2
+        '''
+        sm_manager = SoftwareManager()
+        if not sm_manager.check_installed("gcc") and not sm.install("gcc"):
+            self.error("Gcc is needed for the test to be run")
+        tarball = self.fetch_asset('http://ck.kolivas.org'
+                                   '/apps/interbench/'
+                                   'interbench-0.31.tar.bz2')
+        data_dir = os.path.abspath(self.datadir)
+        archive.extract(tarball, self.srcdir)
+        version = os.path.basename(tarball.split('.tar.')[0])
+        self.srcdir = os.path.join(self.srcdir, version)
+
+        # Patch for make file
+        os.chdir(self.srcdir)
+        makefile_patch = 'patch -p1 < %s ' % (
+            os.path.join(data_dir, 'makefile_fix.patch'))
+        process.run(makefile_patch, shell=True)
+
+        build.make(self.srcdir)
+
+    def test(self):
+        args = self.params.get('arg', default='')
+        args += ' c'
+        process.system("%s ' run ' %s" % (os.path.join(
+            self.srcdir, 'interbench'), args), sudo=True)
+
+if __name__ == "__main__":
+    main()

--- a/generic/interbench.py.data/interbench.yaml
+++ b/generic/interbench.py.data/interbench.yaml
@@ -1,0 +1,4 @@
+setup:
+ runargs : !mux
+  default :
+   args : ''

--- a/generic/interbench.py.data/makefile_fix.patch
+++ b/generic/interbench.py.data/makefile_fix.patch
@@ -1,0 +1,19 @@
+--- interbench-0.31/Makefile.orig	2016-06-29 13:03:04.850843860 -0400
++++ interbench-0.31/Makefile	2016-06-29 13:01:49.214255602 -0400
+@@ -1,9 +1,9 @@
+-CC=gcc
+-CFLAGS=-W -Wall -g -O2 -s -pipe
+-LDFLAGS=-lrt -lm -pthread
+-
+-interbench: interbench.o hackbench.o
+-interbench.o: interbench.c
+-hackbench.o: hackbench.c
++C ?= gcc
++CFLAGS=-W -Wall -g -lpthread -O2 -s -pipe
++LDFLAGS=-lrt -lm -lpthread
++default: 
++	$(CC) $(CFLAGS) -c -o interbench.o  interbench.c
++	$(CC) $(CFLAGS) -c -o hackbench.o  hackbench.c
++	$(CC) interbench.o hackbench.o -o interbench  ${LDFLAGS}
+ clean:
+ 	rm -f *.o interbench interbench.read interbench.write interbench.loops_per_ms *~


### PR DESCRIPTION
Signed-off-by: praveen@linux.vnet.ibm.com
added interbench Test case 
V2 #83 

Changes:
v3: Use os.path.join() to join paths
v3: Fixed variable names
v3: Removed empty space from makefile patch
