### PR TITLE
Test to run gdb testsuite.

### DIFF
--- a/generic/gdb.py
+++ b/generic/gdb.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Pavithra <pavrampu@linux.vnet.ibm.com>
+
+import os
+import re
+from avocado import Test
+from avocado import main
+from avocado.utils import archive
+from avocado.utils import build
+from avocado.utils import process
+from avocado.utils.software_manager import SoftwareManager
+
+
+class GDB(Test):
+
+    def setUp(self):
+        sm = SoftwareManager()
+        for package in ("gcc", "g++", "dejagnu", "flex", "binutils-dev", "bison"):
+            if not sm.check_installed(package) and not sm.install(package):
+                self.error(
+                    "Fail to install %s required for this test." % package)
+        gdb_version = self.params.get('gdb_version', default='7.10')
+        tarball = self.fetch_asset(
+            "http://ftp.gnu.org/gnu/gdb/gdb-%s.tar.gz" % gdb_version)
+        archive.extract(tarball, self.srcdir)
+        self.srcdir = os.path.join(
+            self.srcdir, os.path.basename(tarball.split('.tar')[0]))
+        os.chdir(self.srcdir)
+        process.run('./configure')
+        build.make(self.srcdir)
+
+    def test(self):
+        process.run("make check-gdb", ignore_status=True)
+        logfile = os.path.join(self.logdir, "stdout")
+        fp = open(logfile, "r")
+        for line in fp:
+            for match in re.finditer("of unexpected failures\s[1-9]", line):
+                self.log.info(line)
+                self.fail("Few gdb tests have failed")
+
+if __name__ == "__main__":
+    main()

--- a/generic/gdb.py.data/version.yaml
+++ b/generic/gdb.py.data/version.yaml
@@ -1,0 +1,1 @@
+gdb_version: "7.11"


### PR DESCRIPTION
This python script downloads gdb tar file from http://ftp.gnu.org/gnu/gdb/ and runs gdb testsuite. If number of unexpected failures are greater than zero, result will be marked as FAIL. gdb version can be given in version.yaml file, by default version will be 7.10.
