### PR TITLE
Adding fuzzer test to avocado [V3]

### DIFF
--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+# Based on code by Martin Bligh <mbligh@google.com>
+#   copyright: 2006 Google
+#   https://github.com/autotest/autotest-client-tests/tree/master/fsfuzzer
+
+import os
+import re
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process
+from avocado.utils import git
+from avocado.utils import distro
+from avocado.utils import build
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Fsfuzzer(Test):
+
+    """
+    fsfuzzer is a file system fuzzer tool. This test simply runs fsfuzzer
+    Fuzzing is slang for fault injection via random inputs. The goal is to
+    find bugs in software without reading code or designing detailed test
+    cases.
+       fsfuzz will inject random errors into the files systems
+       mounted. Evidently it has found many errors in many systems.
+    """
+
+    def setUp(self):
+        '''
+        Build fsfuzzer
+        Source:
+        https://github.com/stevegrubb/fsfuzzer.git
+        '''
+        detected_distro = distro.detect()
+
+        smm = SoftwareManager()
+
+        if not smm.check_installed("gcc") and not smm.install("gcc"):
+            self.error("Gcc is needed for the test to be run")
+
+        git.get_repo('https://github.com/stevegrubb/fsfuzzer.git',
+                     destination_dir=self.srcdir)
+
+        os.chdir(self.srcdir)
+
+        if detected_distro.name == "Ubuntu":
+            # Patch for ubuntu
+            fuzz_fix_patch = 'patch -p1 < %s' % (
+                os.path.join(self.datadir, 'fsfuzz_fix.patch'))
+            process.run(fuzz_fix_patch, shell=True)
+
+        process.run('./autogen.sh', shell=True)
+        process.run('./configure', shell=True)
+
+        build.make(self.srcdir)
+
+        self.args = self.params.get('fstype', default='')
+
+        fs_sup = process.system_output('%s %s' % (
+            os.path.join(self.srcdir, 'fsfuzz'), ' --help'))
+
+        matchObj = re.search(r'%s' % self.args, fs_sup, re.M | re.I)
+        if not matchObj:
+            self.skip('File system ' + self.args +
+                      ' is unsupported in ' + detected_distro.name)
+
+    def test(self):
+        '''
+        Runs the fsfuzz test suite. By default uses all supported fstypes,
+        but you can specify only one by `fstype` param.
+        '''
+        process.system('%s  %s' % (os.path.join(
+            self.srcdir, 'fsfuzz'), self.args), shell=True)
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fsfuzzer.py.data/README
+++ b/fuzz/fsfuzzer.py.data/README
@@ -1,0 +1,9 @@
+WARNING: This program can cause your kernel to oops. ITS WHOLE
+PURPOSE IS TO PROVOKE THE COMPUTER TO DO BAD THINGS. If you are
+using a journalling file system for all your important data, for
+the most part you will be OK running this on your machine. But its
+impossible to know what hole in the OS you will trigger and what its
+consequences are. If you don't run with a journalled file system 
+and many processes are active and some writing to disk, there
+is a real good chance that you could screw up your computer. YOU
+HAVE BEEN WARNED!

--- a/fuzz/fsfuzzer.py.data/fsfuzz_fix.patch
+++ b/fuzz/fsfuzzer.py.data/fsfuzz_fix.patch
@@ -1,0 +1,8 @@
+--- fsfuzzer/fsfuzz.org	2016-07-01 10:02:22.193569811 -0400
++++ fsfuzzer/fsfuzz	2016-07-01 10:02:46.729760531 -0400
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ # (c) 2006-2009 Steve Grubb <sgrubb@redhat.com>
+ # (c) 2006, LMH <lmh@info-pull.com>
+ #

--- a/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
+++ b/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
@@ -1,0 +1,36 @@
+setup:
+ filesystem : !mux
+  default : 
+   fstype : '' 
+  cramfs:
+    fstype: cramfs
+  ext2:
+    fstype: ext2
+   ext3:
+    fstype: ext3
+   ext4:
+    fstype: ext4
+   swap:
+    fstype: swap
+   iso9660:
+    fstype: iso9660
+   msdos:
+    fstype: msdos
+   vfat:
+    fstype: vfat
+   xfs:
+    fstype: xfs
+   mksquashfs:
+    fstype: mksquashfs
+   hfs:
+    fstype: hfs
+   gfs2:
+    fstype: gfs2
+   jffs2:
+    fstype: jffs2
+   reiserfs:
+    fstype: reiserfs
+   romfs:
+    fstype: romfs
+   ecryptfs
+    fstype: ecryptfs

--- a/perf/lmbench.py
+++ b/perf/lmbench.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+# Based on code by Martin Bligh <mbligh@google.com>
+#   copyright: 2008 Google
+#   https://github.com/autotest/autotest-client-tests/tree/master/lmbench
+
+import os
+import tempfile
+
+from avocado import Test
+from avocado import main
+from avocado.utils import archive
+from avocado.utils import process
+from avocado.utils import build
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Lmbench(Test):
+
+    """
+    lmbench is a series of micro benchmarks intended to measure basic
+    operating system and hardware system metrics. The benchmarks fall
+    into three general classes: bandwidth, latency, and ``other''.
+    """
+
+    def setUp(self):
+        '''
+        Build lmbench
+        Source:
+        http://www.bitmover.com/lmbench/lmbench3.tar.gz
+        '''
+        fsdir = self.params.get('fsdir', default=None)
+        temp_file = self.params.get('temp_file', default=None)
+        self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
+        smm = SoftwareManager()
+        if not smm.check_installed("gcc") and not smm.install("gcc"):
+            self.error("Gcc is needed for the test to be run")
+        tarball = self.fetch_asset('http://www.bitmover.com'
+                                   '/lmbench/lmbench3.tar.gz')
+        data_dir = os.path.abspath(self.datadir)
+        archive.extract(tarball, self.srcdir)
+        version = os.path.basename(tarball.split('.tar.')[0])
+        self.srcdir = os.path.join(self.srcdir, version)
+
+        # Patch for lmbench
+
+        os.chdir(self.srcdir)
+
+        makefile_patch = 'patch -p1 < %s' % (
+            os.path.join(data_dir, 'makefile.patch'))
+        build_patch = 'patch -p1 < %s' % (os.path.join(
+            data_dir, '0001-Fix-build-issues-with-lmbench.patch'))
+        lmbench_fix_patch = 'patch -p1 < %s' % (os.path.join(
+            data_dir, '0002-Changing-shebangs-on-lmbench-scripts.patch'))
+        ostype_fix_patch = 'patch -p1 < %s' % (
+            os.path.join(data_dir, 'fix_add_os_type.patch'))
+
+        process.run(makefile_patch, shell=True)
+        process.run(build_patch, shell=True)
+        process.run(lmbench_fix_patch, shell=True)
+        process.run(ostype_fix_patch, shell=True)
+
+        build.make(self.srcdir)
+
+        # configure lmbench
+        os.chdir(self.srcdir)
+
+        os.system('yes "" | make config')
+
+        # find the lmbench config file
+        output = os.popen('ls -1 bin/*/CONFIG*').read()
+        config_files = output.splitlines()
+        if len(config_files) != 1:
+            raise error.TestError('Config not found : % s' % config_files)
+        config_file = config_files[0]
+        if not fsdir:
+            fsdir = self.tmpdir
+        if not temp_file:
+            temp_file = os.path.join(self.tmpdir, 'XXX')
+
+        # patch the resulted config to use the proper temporary directory and
+        # file locations
+        tmp_config_file = config_file + '.tmp'
+        process.system('touch ' + tmp_config_file)
+        process.system("sed 's!^FSDIR=.*$!FSDIR=%s!' '%s'  '%s' " %
+                       (fsdir, config_file, tmp_config_file))
+        process.system("sed 's!^FILE=.*$!FILE=%s!' '%s'  '%s'" %
+                       (temp_file, tmp_config_file, config_file))
+
+    def test(self):
+
+        os.chdir(self.srcdir)
+        build.make(self.srcdir, extra_args='rerun')
+
+if __name__ == "__main__":
+    main()

--- a/perf/lmbench.py.data/0001-Fix-build-issues-with-lmbench.patch
+++ b/perf/lmbench.py.data/0001-Fix-build-issues-with-lmbench.patch
@@ -1,0 +1,173 @@
+From 05546bfc9968a58e9569f2a8a9764f6e53f20167 Mon Sep 17 00:00:00 2001
+From: Lucas Meneghel Rodrigues <lmr@redhat.com>
+Date: Thu, 8 Apr 2010 10:38:13 -0300
+Subject: [PATCH 1/2] Fix build issues with lmbench
+
+* removes Makefile references to bitkeeper
+* default mail to no, fix job placement defaults (masouds)
+* adds "config" Makefile targets to perform configuration only
+* changes scripts/getlist to consider result files that do
+* not start with "[lmbench 3.x..." (still requires such a line somewhere
+  in the first 1000 bytes of the file)
+---
+ Makefile           |    4 ++++
+ scripts/config-run |   13 ++++++++-----
+ scripts/getlist    |    4 ++--
+ src/Makefile       |   44 ++++++--------------------------------------
+ 4 files changed, 20 insertions(+), 45 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d3d00f4..9a568f3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,6 +5,7 @@
+ #
+ # build		(default) go to the source directory and build the benchmark
+ # results	go to the source directory and build and run the benchmark
++# config	configures run parameters
+ # rerun		run the benchmark again
+ # see		see the results that came with this release
+ #		Go to the results directory and read the Makefile.
+@@ -22,6 +23,9 @@ build:
+ results: FRC
+ 	cd src && $(MAKE) results
+ 
++config:
++	cd src && $(MAKE) config
++
+ rerun: 
+ 	cd src && $(MAKE) rerun
+ 
+diff --git a/scripts/config-run b/scripts/config-run
+index b8c17d5..9958a31 100755
+--- a/scripts/config-run
++++ b/scripts/config-run
+@@ -115,9 +115,12 @@ three attendent child processes sending data down the pipes and
+ three benchmark processes reading data and doing the measurements.
+ 
+ EOF
+-	echo $ECHON "Job placement selection: $ECHOC"
++	echo $ECHON "Job placement selection [DEFAULT: 1]: $ECHOC"
+ 	read LMBENCH_SCHED
+ 	AGAIN=N
++	if [ "$LMBENCH_SCHED" == "" ]; then
++		LMBENCH_SCHED=1
++	fi
+ 	case "$LMBENCH_SCHED" in
+ 	    1) LMBENCH_SCHED=DEFAULT;;
+ 	    2) LMBENCH_SCHED=BALANCED;;
+@@ -657,13 +660,13 @@ fast box, they may be made available on the lmbench web page, which is
+ 
+ EOF
+ 
+-echo $ECHON "Mail results [default yes] $ECHOC"
++echo $ECHON "Mail results [default no] $ECHOC"
+ read MAIL
+ case $MAIL in 
+-    [Nn]*)	MAIL=no
+-		echo OK, no results mailed.
++    [Yy]*)	MAIL=yes
++		echo OK, results will be mailed.
+ 		;;
+-    *)		MAIL=yes
++    *)		MAIL=no
+ 		;;
+ esac
+ 
+diff --git a/scripts/getlist b/scripts/getlist
+index 8c35970..f03b679 100755
+--- a/scripts/getlist
++++ b/scripts/getlist
+@@ -22,9 +22,9 @@ if (-f $LIST) {
+ foreach $file (@files) {
+ 	next if $file =~ /\.INFO$/;
+ 	open(FD, $file) || next;
+-	next unless defined($_ = <FD>);
++	next unless read(FD, $_, 1000);
+ 	close(FD);
+-	next unless /^\[lmbench3.[01]/;
++	next unless /^\[lmbench3.[01]/m;
+ 	print "$file ";
+ }
+ print "\n";
+diff --git a/src/Makefile b/src/Makefile
+index 2555014..cf0b779 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -4,6 +4,7 @@
+ #
+ # lmbench	[default] builds the benchmark suite for the current os/arch
+ # results	builds, configures run parameters, and runs the benchmark
++# config	configures run parameters
+ # rerun		reruns the benchmark using the same parameters as last time
+ # scaling	reruns the benchmark using same parameters as last time,
+ #		except it asks what scaling value to use
+@@ -118,8 +119,10 @@ results: lmbench
+ 	@env OS="${OS}" ../scripts/config-run
+ 	@env OS="${OS}" ../scripts/results
+ 
+-rerun: lmbench
++config: lmbench
+ 	@if [ ! -f $(CONFIG) ]; then env OS="${OS}" ../scripts/config-run; fi
++
++rerun: lmbench config
+ 	@env OS="${OS}" ../scripts/results
+ 
+ scaling: lmbench
+@@ -165,41 +168,6 @@ debug:
+ assembler:
+ 	@env CFLAGS=-O MAKE="$(MAKE)" MAKEFLAGS="$(MAKEFLAGS)" CC="${CC}" OS="${OS}" ../scripts/build asm
+ 
+-bk.ver: ../SCCS/s.ChangeSet
+-	rm -f bk.ver
+-	-echo `bk prs -hr+ -d'$$if(:SYMBOL:){:SYMBOL: }:UTC:' ../ChangeSet;` > bk.ver
+-	touch bk.ver
+-
+-dist: bk.ver
+-	@if [ "X`cd ..; bk sfiles -c`" != "X" ]; then \
+-		echo "modified files!"; \
+-		false; \
+-	 fi
+-	@if [ "X`cd ..; bk pending`" != "X" ]; then \
+-		echo "pending changes!"; \
+-		false; \
+-	 fi
+-	cd ..; \
+-		SRCDIR=`pwd`; \
+-		DIR=`basename $${SRCDIR}`; \
+-		VERSION=`cat src/bk.ver| awk '{print $$1;}' | sed -e 's/Version-//g'`; \
+-		cd ..; \
+-		bk clone $${DIR} /tmp/lmbench-$${VERSION}; \
+-		cd /tmp/lmbench-$${VERSION}; \
+-		bk sfiles | xargs touch; \
+-		sleep 5; \
+-		bk get -s; \
+-		for d in doc results scripts src; do \
+-			cd $$d; bk get -s; cd ..; \
+-		done; \
+-		bk sfiles -U -g | xargs touch; \
+-		cd src; \
+-		make bk.ver; \
+-		cd /tmp; \
+-		tar czf $${SRCDIR}/../lmbench-$${VERSION}.tgz \
+-			lmbench-$${VERSION}; \
+-		rm -rf /tmp/lmbench-$${VERSION};
+-
+ get $(SRCS):
+ 	-get -s $(SRCS)
+ 
+@@ -228,9 +196,9 @@ testmake: $(SRCS) $(UTILS) # used by scripts/make to test gmake
+ 	install install-target dist get edit get-e clean clobber \
+ 	share depend testmake
+ 
+-$O/lmbench : ../scripts/lmbench bk.ver
++$O/lmbench : ../scripts/lmbench
+ 	rm -f $O/lmbench
+-	sed -e "s/<version>/`cat bk.ver`/g" < ../scripts/lmbench > $O/lmbench
++	sed -e "s/<version>/666/g" < ../scripts/lmbench > $O/lmbench
+ 	chmod +x $O/lmbench
+ 
+ $O/lmbench.a: $(LIBOBJS)
+-- 
+1.6.6.1
+

--- a/perf/lmbench.py.data/0002-Changing-shebangs-on-lmbench-scripts.patch
+++ b/perf/lmbench.py.data/0002-Changing-shebangs-on-lmbench-scripts.patch
@@ -1,0 +1,204 @@
+From 7fc9ef8ce9ce630b53b20f1d4207c587df9b9763 Mon Sep 17 00:00:00 2001
+From: Lucas Meneghel Rodrigues <lmr@redhat.com>
+Date: Thu, 8 Apr 2010 09:57:10 -0300
+Subject: [PATCH 2/2] Changing shebangs on lmbench scripts
+
+Some distros such as ubuntu use dash as the default
+shell, and lmbench scripts use constructs incompatible
+with it. So, at least for ubuntu, let's change the
+shebangs from /bin/sh to /bin/bash.
+
+Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>
+---
+ scripts/build          |    2 +-
+ scripts/compiler       |    2 +-
+ scripts/config         |    2 +-
+ scripts/config-run     |    2 +-
+ scripts/config-scaling |    2 +-
+ scripts/do_ctx         |    2 +-
+ scripts/info           |    2 +-
+ scripts/lmbench        |    2 +-
+ scripts/make           |    2 +-
+ scripts/mkrelease      |    2 +-
+ scripts/os             |    2 +-
+ scripts/output         |    2 +-
+ scripts/results        |    2 +-
+ scripts/synchronize    |    2 +-
+ scripts/target         |    2 +-
+ scripts/version        |    2 +-
+ scripts/xroff          |    2 +-
+ 17 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/scripts/build b/scripts/build
+index 16a6600..7f0d41e 100755
+--- a/scripts/build
++++ b/scripts/build
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ CC=${CC-`../scripts/compiler`}
+ MAKE=${MAKE-`../scripts/make`}
+diff --git a/scripts/compiler b/scripts/compiler
+index 2fca921..de57298 100755
+--- a/scripts/compiler
++++ b/scripts/compiler
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ "X$CC" != "X" ] && echo "$CC" | grep -q '`'
+ then
+diff --git a/scripts/config b/scripts/config
+index b58cb60..2c0276d 100755
+--- a/scripts/config
++++ b/scripts/config
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ UNAME=`uname -n 2>/dev/null`
+ if [ X$UNAME = X ]
+diff --git a/scripts/config-run b/scripts/config-run
+index 9958a31..76ead34 100755
+--- a/scripts/config-run
++++ b/scripts/config-run
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # Configure parameters for lmbench.
+ # %I% %E% %@%
+diff --git a/scripts/config-scaling b/scripts/config-scaling
+index 12e0f02..03f3e38 100755
+--- a/scripts/config-scaling
++++ b/scripts/config-scaling
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # config-scaling - reconfigure just the scaling parameter SYNC_MAX
+ #
+diff --git a/scripts/do_ctx b/scripts/do_ctx
+index 002a6c2..2b1db4c 100755
+--- a/scripts/do_ctx
++++ b/scripts/do_ctx
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # Make sure we can find: ./cmd, df, and netstat
+ PATH=.:$PATH:/etc:/usr/etc:/sbin:/usr/sbin
+diff --git a/scripts/info b/scripts/info
+index e6860ed..18a10b2 100755
+--- a/scripts/info
++++ b/scripts/info
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ UNAME=`uname -n 2>/dev/null`
+ if [ X$UNAME = X ]
+diff --git a/scripts/lmbench b/scripts/lmbench
+index 53ea511..63e5e07 100755
+--- a/scripts/lmbench
++++ b/scripts/lmbench
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # lmbench - run the lmbench benchmark suite.
+ #
+diff --git a/scripts/make b/scripts/make
+index 59bf238..2886ba6 100755
+--- a/scripts/make
++++ b/scripts/make
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ "X$MAKE" != "X" ] && echo "$MAKE" | grep -q '`'
+ then
+diff --git a/scripts/mkrelease b/scripts/mkrelease
+index be50f03..656f9dd 100755
+--- a/scripts/mkrelease
++++ b/scripts/mkrelease
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # %W%
+ #
+diff --git a/scripts/os b/scripts/os
+index ea767c6..c9aed11 100755
+--- a/scripts/os
++++ b/scripts/os
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ "X$OS" != "X" ] && echo "$OS" | grep -q '`'
+ then
+diff --git a/scripts/output b/scripts/output
+index 2a204e3..a27571a 100755
+--- a/scripts/output
++++ b/scripts/output
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ trap "echo /dev/null" 20
+ OUTPUT=/dev/null; export OUTPUT
+ if [ -w /dev/tty ]; then
+diff --git a/scripts/results b/scripts/results
+index cd07c15..5f817d9 100755
+--- a/scripts/results
++++ b/scripts/results
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # $Id$
+ 
+diff --git a/scripts/synchronize b/scripts/synchronize
+index 302db00..eb36d5b 100755
+--- a/scripts/synchronize
++++ b/scripts/synchronize
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # %W% %@% Copyright (c) 1998 Larry McVoy.
+ #
+diff --git a/scripts/target b/scripts/target
+index 77eee07..6998da9 100755
+--- a/scripts/target
++++ b/scripts/target
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # Figure out the OS name if possible.
+ #
+diff --git a/scripts/version b/scripts/version
+index 879b700..9e6bf6c 100755
+--- a/scripts/version
++++ b/scripts/version
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # %W% %@%
+ 
+diff --git a/scripts/xroff b/scripts/xroff
+index d5acf20..02c61d2 100755
+--- a/scripts/xroff
++++ b/scripts/xroff
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # X previewer like groff/nroff scripts.
+ groff -P -filename -P "| groff -Z -X -Tps $*" -X -Tps "$@" 
+-- 
+1.6.6.1
+

--- a/perf/lmbench.py.data/fix_add_os_type.patch
+++ b/perf/lmbench.py.data/fix_add_os_type.patch
@@ -1,0 +1,12 @@
+--- lmbench3/scripts/gnu-os.orig	2014-10-08 14:40:32.376372883 +0530
++++ lmbench3/scripts/gnu-os	2014-10-08 14:42:36.860375848 +0530
+@@ -883,6 +883,9 @@
+     ppc64:Linux:*:*)
+ 	echo powerpc64-unknown-linux-gnu
+ 	exit 0 ;;
++    ppc64le:Linux:*:*)
++        echo powerpc64le-unknown-linux-gnu
++        exit 0 ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;

--- a/perf/lmbench.py.data/lmbench.yaml
+++ b/perf/lmbench.py.data/lmbench.yaml
@@ -1,0 +1,7 @@
+setup:
+   tem_dir: !mux
+    default:
+     fsdir: None
+   temp_file: !mux
+    default:
+     tem_file: None

--- a/perf/lmbench.py.data/makefile.patch
+++ b/perf/lmbench.py.data/makefile.patch
@@ -1,0 +1,14 @@
+--- lmbench3/src/Makefile.orig	2011-02-07 20:17:46.000000000 -0800
++++ lmbench3/src/Makefile	2011-02-07 20:18:02.000000000 -0800
+@@ -34,9 +34,9 @@
+ # I finally know why Larry Wall's Makefile says "Grrrr".
+ SHELL=/bin/sh
+ 
+-CC=`../scripts/compiler`
++CC ?= `../scripts/compiler`
+ MAKE=`../scripts/make`
+-AR=ar
++AR ?= ar
+ ARCREATE=cr
+ 
+ # base of installation location


### PR DESCRIPTION
Signed-off-by: praveen@linux.vnet.ibm.com
added fuzzer Test case
V2 #66 

Changes:

```
v3: Use the fsfuzzer test code  from git
v3 : execute autogen to generate config
v3: Check input fstype  supported by  Distro if not than skip  test
v3: Added all Fstype (supported by fsfuzz ) in ymal file 
v3: Use os.path.join() to join paths
v3: Fixed variable names
v3: add patch that enable fsfuzz run in ubuntu as well
v3: added doc string about run
v3: hard coded patch in python file 
```
