### PR TITLE
fuzz: Add fsfuzzer test [v4]

### DIFF
--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -77,8 +77,8 @@ class Fsfuzzer(Test):
         fs_sup = process.system_output('%s %s' % (
             os.path.join(self.srcdir, 'fsfuzz'), ' --help'))
 
-        matchObj = re.search(r'%s' % self.args, fs_sup, re.M | re.I)
-        if not matchObj:
+        match = re.search(r'%s' % self.args, fs_sup, re.M | re.I)
+        if not match:
             self.skip('File system ' + self.args +
                       ' is unsupported in ' + detected_distro.name)
 

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -64,7 +64,8 @@ class Fsfuzzer(Test):
             # Patch for ubuntu
             fuzz_fix_patch = 'patch -p1 < %s' % (
                 os.path.join(self.datadir, 'fsfuzz_fix.patch'))
-            process.run(fuzz_fix_patch, shell=True)
+            if process.system(fuzz_fix_patch, shell=True, ignore_status=True):
+                self.log.warn("Unable to apply sh->bash patch!")
 
         process.run('./autogen.sh', shell=True)
         process.run('./configure', shell=True)

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+# Based on code by Martin Bligh <mbligh@google.com>
+#   copyright: 2006 Google
+#   https://github.com/autotest/autotest-client-tests/tree/master/fsfuzzer
+
+import os
+import re
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process
+from avocado.utils import git
+from avocado.utils import distro
+from avocado.utils import build
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Fsfuzzer(Test):
+
+    """
+    fsfuzzer is a file system fuzzer tool. This test simply runs fsfuzzer
+    Fuzzing is slang for fault injection via random inputs. The goal is to
+    find bugs in software without reading code or designing detailed test
+    cases.
+       fsfuzz will inject random errors into the files systems
+       mounted. Evidently it has found many errors in many systems.
+    """
+
+    def setUp(self):
+        '''
+        Build fsfuzzer
+        Source:
+        https://github.com/stevegrubb/fsfuzzer.git
+        '''
+        detected_distro = distro.detect()
+
+        smm = SoftwareManager()
+
+        if not smm.check_installed("gcc") and not smm.install("gcc"):
+            self.error("Gcc is needed for the test to be run")
+
+        git.get_repo('https://github.com/stevegrubb/fsfuzzer.git',
+                     destination_dir=self.srcdir)
+
+        os.chdir(self.srcdir)
+
+        if detected_distro.name == "Ubuntu":
+            # Patch for ubuntu
+            fuzz_fix_patch = 'patch -p1 < %s' % (
+                os.path.join(self.datadir, 'fsfuzz_fix.patch'))
+            process.run(fuzz_fix_patch, shell=True)
+
+        process.run('./autogen.sh', shell=True)
+        process.run('./configure', shell=True)
+
+        build.make(self.srcdir)
+
+        self.args = self.params.get('fstype', default='')
+
+        fs_sup = process.system_output('%s %s' % (
+            os.path.join(self.srcdir, 'fsfuzz'), ' --help'))
+
+        matchObj = re.search(r'%s' % self.args, fs_sup, re.M | re.I)
+        if not matchObj:
+            self.skip('File system ' + self.args +
+                      ' is unsupported in ' + detected_distro.name)
+
+    def test(self):
+
+        '''
+        Runs the fsfuzz test suite. By default uses all supported fstypes,
+        but you can specify only one by `fstype` param.
+        '''
+        process.system('%s %s' % (os.path.join(
+            self.srcdir, 'fsfuzz'), self.args), sudo=True)
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fsfuzzer.py.data/README
+++ b/fuzz/fsfuzzer.py.data/README
@@ -1,0 +1,9 @@
+WARNING: This program can cause your kernel to oops. ITS WHOLE
+PURPOSE IS TO PROVOKE THE COMPUTER TO DO BAD THINGS. If you are
+using a journalling file system for all your important data, for
+the most part you will be OK running this on your machine. But its
+impossible to know what hole in the OS you will trigger and what its
+consequences are. If you don't run with a journalled file system 
+and many processes are active and some writing to disk, there
+is a real good chance that you could screw up your computer. YOU
+HAVE BEEN WARNED!

--- a/fuzz/fsfuzzer.py.data/fsfuzz_fix.patch
+++ b/fuzz/fsfuzzer.py.data/fsfuzz_fix.patch
@@ -1,0 +1,8 @@
+--- fsfuzzer/fsfuzz.org	2016-07-01 10:02:22.193569811 -0400
++++ fsfuzzer/fsfuzz	2016-07-01 10:02:46.729760531 -0400
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ # (c) 2006-2009 Steve Grubb <sgrubb@redhat.com>
+ # (c) 2006, LMH <lmh@info-pull.com>
+ #

--- a/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
+++ b/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
@@ -1,7 +1,5 @@
 setup:
  filesystem: !mux
-    default:
-        fstype: ''
     cramfs:
         fstype: cramfs
     ext2:

--- a/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
+++ b/fuzz/fsfuzzer.py.data/fsfuzzer.yaml
@@ -1,0 +1,36 @@
+setup:
+ filesystem: !mux
+    default:
+        fstype: ''
+    cramfs:
+        fstype: cramfs
+    ext2:
+        fstype: ext2
+    ext3:
+        fstype: ext3
+    ext4:
+        fstype: ext4
+    swap:
+        fstype: swap
+    iso9660:
+        fstype: iso9660
+    msdos:
+        fstype: msdos
+    vfat:
+        fstype: vfat
+    xfs:
+        fstype: xfs
+    mksquashfs:
+        fstype: mksquashfs
+    hfs:
+        fstype: hfs
+    gfs2:
+        fstype: gfs2
+    jffs2:
+        fstype: jffs2
+    reiserfs:
+        fstype: reiserfs
+    romfs:
+        fstype: romfs
+    ecryptfs:
+        fstype: ecryptfs


### PR DESCRIPTION
This PR adds fsfuzzer test which verifies that random patterns are handled correctly on various filesystems.

v3: https://github.com/avocado-framework/avocado-misc-tests/pull/92

Changes:

```
v3:  Use the fsfuzzer test code  from git
v3 : Execute autogen to generate config
v3:  Check input fstype  supported by  Distro if not than skip  test
v3:  Added all Fstype (supported by fsfuzz ) in ymal file 
v3:  Use os.path.join() to join paths
v3:  Fixed variable names
v3:  Add patch that enable fsfuzz to run on ubuntu as well
v3:  Added doc string about run
v3:  Hard coded patch in python file 
v4: Fix typo in yaml file
v4: Add sudo=True and remove shell from fsfuzzer execution
v4: New commit to turn patch failures to warnings
v4: New commit with pylint fixes
v4: New commit to fetch_asset as zip rather than git clone
v4: New commit to remove default from yaml file
```
