### PR TITLE
Adding syscall fuzzer(trinity) test to avocado

### DIFF
--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+
+import os
+import re
+
+from avocado import Test
+from avocado import main
+from avocado.utils import archive, build, process
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Trinity(Test):
+
+    """
+    This testsuite test  syscall by calling syscall
+    with random system call and varying number of args
+    """
+
+    def setUp(self):
+        '''
+        Build Trinity
+        Source:
+        https://github.com/kernelslacker/trinity
+        '''
+
+        process.run('useradd  trinity', sudo=True)
+
+        smm = SoftwareManager()
+
+        for package in ("gcc", "make"):
+            if not smm.check_installed(package) and not smm.install(package):
+                self.error(
+                    "Fail to install %s required for this test." % package)
+
+        locations = ["https://github.com/kernelslacker/trinity/archive/"
+                     "master.zip"]
+        tarball = self.fetch_asset("trinity.zip", locations=locations)
+        archive.extract(tarball, self.srcdir)
+        self.srcdir = os.path.join(self.srcdir, 'trinity-master')
+
+        os.chdir(self.srcdir)
+
+        process.run('chmod -R  +x ' + self.srcdir)
+        process.run('./configure', shell=True)
+        build.make('.')
+
+    def test(self):
+        '''
+        Trinity need to run as non root user
+        '''
+        args = self.params.get('runarg', default='-x madasive ')
+
+        process.system('su - trinity -c " %s  %s  %s"' %
+                       (os.path.join(self.srcdir, 'trinity'), args, '-N 100000'),
+                       shell=True)
+
+        dmesg = process.system_output('dmesg')
+
+        # verify if system having issue after fuzzer run
+
+        match = re.search(r'unhandled', dmesg, re.M | re.I)
+        if match:
+            self.log.info("Testcase failure as segfault")
+        match = re.search(r'Call Trace:', dmesg, re.M | re.I)
+        if match:
+            self.log.info("some call traces seen please check")
+
+    def tearDown(self):
+
+        process.system('userdel trinity', sudo=True)
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/trinity.py.data/README
+++ b/fuzz/trinity.py.data/README
@@ -1,0 +1,14 @@
+WARNINGS:
+* This program may seriously corrupt your files, including any
+  of those that may be writable on mounted network file shares.
+  It may create network packets that may cause disruption on your
+   local network.
+
+* Trinity may generate the right selection of syscalls to start
+  sending random network  packets to other hosts. While every effort
+   is made to restrict this to IP addresses  on local lans, multicast
+   & broadcast, care should be taken to not allow the  packets it generates
+   to go out onto the internet.
+
+there is a real good chance that you could screw up your computer. YOU
+HAVE BEEN WARNED!

--- a/fuzz/trinity.py.data/trinity.yaml
+++ b/fuzz/trinity.py.data/trinity.yaml
@@ -1,0 +1,36 @@
+#./trinity
+# --arch, -a: selects syscalls for the specified architecture (32 or 64). Both by default.
+# --bdev, -b <node>:  Add /dev node to list of block devices to use for destructive tests..
+# --children,-C: specify number of child processes
+# --debug,-D: enable debug
+# --dropprivs, -X: if run as root, switch to nobody [EXPERIMENTAL]
+# --exclude,-x: don't call a specific syscall
+# --enable-fds/--disable-fds= {sockets,pipes,perf,epoll,eventfd,pseudo,timerfd,testfile,memfd,drm}
+# --group,-g = {vfs,vm}: only run syscalls from a certain group.
+# --ioctls,-I: list all ioctls.
+# --kernel_taint, -T: controls which kernel taint flags should be considered, for more details refer to README file. 
+# --list,-L: list all syscalls known on this architecture.
+# --logging,-l: (off=disable logging).
+# --monochrome,-m: don't output ANSI codes
+# --domain,-P: specify specific network domain for sockets.
+# --no_domain,-E: specify network domains to be excluded from testing.
+# --quiet,-q: less output.
+# --random,-r#: pick N syscalls at random and just fuzz those
+# --server_addr: supply an IPv4 or IPv6 address to connect, no need for server side.
+# --server_port: supply an server port to listen or connect, will fuzz between port to (port + 100)
+# --syslog,-S: log important info to syslog. (useful if syslog is remote)
+# --verbose,-v: increase output verbosity.
+# --victims,-V: path to victim files.
+
+# -c#,@: target specific syscall (takes syscall name as parameter and optionally 32 or 64 as bit-width. Default:both).
+# -N#: do # syscalls then exit.
+# -s#: use # as random seed.
+
+setup:
+ trinityrun : !mux
+  exclude:
+   runargs :  -x madvise
+  logging_off:
+   runargs :  -qq -l off -C16
+ 
+  


### PR DESCRIPTION
Signed-off-by: praveen@linux.vnet.ibm.com
added trinity (new) Test case 

```

v1: fetch syscall fuzzer from git (https://github.com/kernelslacker/trinity)
v1: crate a non root user to run test suite 
v1: run ./configure and make
v1: invoke trinity exe 
v1:verify after run if there problem reported in dmesg 
v1: problem reported than notify user to evaluate the problem 
```
