### PR TITLE
Adding xfstests test to avocado

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2016 IBM
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#
+# Based on code by Cleber Rosa <crosa@redhat.com>
+#   copyright: 2011 Redhat
+#   https://github.com/autotest/autotest-client-tests/tree/master/xfstests
+
+
+import os
+import glob
+import re
+import shutil
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, git, distro
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Xfstests(Test):
+
+    PASSED_RE = re.compile(r'Passed all \d+ tests')
+    FAILED_RE = re.compile(r'Failed \d+ of \d+ tests')
+    NA_RE = re.compile(r'Passed all 0 tests')
+    NA_DETAIL_RE = re.compile(r'(\d{3})\s*(\[not run\])\s*(.*)')
+    GROUP_TEST_LINE_RE = re.compile('(\d{3})\s(.*)')
+
+    def setUp(self):
+        '''
+        Build xfstest
+        Source:
+        git://oss.sgi.com/xfs/cmds/xfstests
+        '''
+
+        # Check for basic utilities
+        sm = SoftwareManager()
+        detected_distro = distro.detect()
+
+        packages = ['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'e2fsprogs',
+                    'automake',  'gcc', 'libuuid1', 'quota', 'attr',
+                    'libattr1-dev', 'make', 'libacl1-dev', 'xfsprogs',
+                    'libgdbm-dev', 'gawk', 'fio', 'dbench', 'uuid-runtime']
+        for package in packages:
+            if not sm.check_installed(package) and not sm.install(package):
+                self.error(
+                    "Fail to install %s required for this test." % package)
+        data_dir = os.path.abspath(self.datadir)
+        git.get_repo('git://oss.sgi.com/xfs/cmds/xfstests',
+                     destination_dir=self.srcdir)
+        os.chdir(self.srcdir)
+        shutil.copyfile(data_dir + '/group',
+                        os.path.join(self.srcdir, 'group'))
+        build.make(self.srcdir)
+
+        process.run('useradd fsgqa', sudo=True)
+        process.run('useradd 123456-fsgqa', sudo=True)
+
+        self.log.info("Available tests in srcdir: %s" %
+                      ", ".join(self._get_available_tests()))
+
+    def _get_available_tests(self):
+        os.chdir(self.srcdir)
+
+        tests = glob.glob(self.srcdir + '/tests/*/???.out')
+        tests += glob.glob(self.srcdir + '/tests/*/???.out.linux')
+        tests = [t.replace('.linux', '') for t in tests]
+        tests_list = [t[-7:-4] for t in tests if os.path.exists(t[:-4])]
+        tests_list.append('')
+        tests_list.sort()
+        return tests_list
+
+    def _run_sub_test(self, test):
+
+        os.chdir(self.srcdir)
+        output = process.system_output('./check %s' % test,
+                                       ignore_status=True)
+        lines = output.split('\n')
+        result_line = lines[-3]
+        if self.NA_RE.match(result_line):
+            detail_line = lines[-3]
+            match = self.NA_DETAIL_RE.match(detail_line)
+            if match is not None:
+                error_msg = match.groups()[2]
+            else:
+                error_msg = 'Test dependency failed, test not run'
+            raise self.error(error_msg)
+
+        elif self.FAILED_RE.match(result_line):
+            raise self.error('Test error, check debug logs for complete '
+                             'test output')
+
+        elif self.PASSED_RE.match(result_line):
+            return
+
+        else:
+            raise self.error('Could not assert test success or failure, '
+                             'assuming failure. Please check debug logs')
+
+    def _get_groups(self):
+        '''
+        Returns the list of groups known to xfstests
+        By reading the group file and identifying unique mentions of groups
+        '''
+        groups = []
+        for l in open(os.path.join(self.srcdir, 'group')).readlines():
+            m = self.GROUP_TEST_LINE_RE.match(l)
+            if m is not None:
+                groups = m.groups()[1].split()
+                for g in groups:
+                    if g not in groups:
+                        groups.add(g)
+        return groups
+
+    def _get_tests_for_group(self, group):
+        '''
+        Returns the list of tests that belong to a certain test group
+        '''
+        tests = []
+        for l in open(os.path.join(self.srcdir, 'group')).readlines():
+            m = self.GROUP_TEST_LINE_RE.match(l)
+            if m is not None:
+                test = m.groups()[0]
+                groups = m.groups()[1]
+                if group in groups.split():
+                    if test not in tests:
+                        tests.append(test)
+        return tests
+
+    def test(self):
+
+        os.chdir(self.srcdir)
+        test_number = self.params.get('test_number', default='')
+        skip_dangerous = self.params.get('skip_dangerous', default=True)
+        if test_number == '000':
+            self.log.info('Dummy test to setup xfstests')
+            return
+
+        if test_number not in self._get_available_tests():
+            raise self.error('test file %s not found' % test_number)
+
+        if skip_dangerous:
+            if test_number in self._get_tests_for_group('dangerous'):
+                raise self.error('test is dangerous, skipped')
+
+        self.log.info("Running test: %s" % test_number)
+
+        if test_number:
+            test_number = '*/' + test_number
+
+        self._run_sub_test(test_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -1,0 +1,43 @@
+This is a simple wrapper for running xfstests inside avocado. The steps to get
+started are really simple:
+
+1) Edit the configuration variables on the yaml file as well environment variable
+
+1.1) The variables 'TEST_DEV' and 'TEST_DIR' are mandatory and should be set to
+     a block device path and mount point path, respectively, that will be used
+     *exclusively* for xfstests. It must have the filesystem of your choice
+     previously created.
+     ex : export TEST_DEV =/dev/vda1 , export TEST_DIR=/mnt
+
+     DO NOT USE A BLOCK DEVICE WITH IMPORTANT DATA!!!
+
+1.2) Set the range of tests you want to run setting the TEST_RANGE variable.
+     Please notice that python's range() function may not work as you expect,
+     that is, if you want a range from 0-255, use: range(0, 256)
+
+General notes
+-------------
+
+* As autotest includes a setup phase for client tests, this step is encapsulated
+in a dummy xfstests number 000.
+
+* XFS utilities, system libraries and header files are checked early, before
+trying to build xfstests. Make sure you resolve those dependencies.
+
+* Some tests are not relevant to filesystems other than XFS, so they will return
+as TEST_NA.
+
+* Be extra careful when using TEST_DEV with device-mapper based block devices.
+For instance, xfstests may not be able to figure out that /dev/<vg>/<lv> is
+actually a link to /dev/mapper/vg-lv. Tests will then fail to check that the
+device is mounted.
+
+* As a convenience the default config file uses a virtual partition, so people
+can try it out the tests without having an actual spare device. However the
+virtual partition depends on the following programs to be available:
+     * sfdisk
+     * losetup
+     * kpartx
+Make sure you have them or a real spare device to test things.
+"""
+

--- a/fs/xfstests.py.data/group
+++ b/fs/xfstests.py.data/group
@@ -1,0 +1,407 @@
+# QA groups control file
+# Defines test groups and nominal group owners
+# - do not start group names with a digit
+# - comment line before each group is "new" description
+#
+
+# catch-all
+other           fsg@melbourne.sgi.com
+
+# read/write integrity
+rw              dxm@sgi.com
+
+# directory operations, e.g. create/unlink
+dir             dxm@sgi.com
+
+# metadata and inodes in particular
+metadata        dxm@sgi.com
+
+# xfs_db
+db              nathans@sgi.com dxm@sgi.com
+
+# extended attributes
+attr            nathans@sgi.com dxm@sgi.com
+
+# xfs_logprint
+logprint        tes@sgi.com dxm@sgi.com
+
+# XFS log related testing
+log             tes@sgi.com
+
+# XFS log related testing
+v2log           tes@sgi.com
+
+# xfsdump, xfsrestore, xfsinvutil
+dump            tes@sgi.com ivanr@sgi.com
+
+# xfsdump, xfsrestore to tapes
+tape            tes@sgi.com ivanr@sgi.com
+
+# xfsdump, xfsrestore to remote tapes
+remote          tes@sgi.com ivanr@sgi.com
+
+# xfs_copy
+copy            harshula@sgi.com
+
+# chacl, libacl
+acl             tes@sgi.com
+
+# capabilities
+cap             tes@sgi.com
+
+# permissions
+perms           tes@sgi.com
+
+# xfs_growfs
+growfs          ajag@sgi.com
+
+# fsr.xfs
+fsr             ajag@sgi.com
+
+# mkfs.xfs
+mkfs            nathans@sgi.com
+
+# xfs_repair
+repair          nathans@sgi.com
+
+# quota tools and XFS quota kernel code (XQM)
+quota           nathans@sgi.com
+
+# auto - tests to be run as part of nightly qa
+auto            dxm@sgi.com
+
+# ioctl - tests which use ioctl commands (directly/indirectly)
+ioctl           nathans@sgi.com
+
+# udf filesystem
+udf             ajones@sgi.com
+
+# AIO operations
+aio             nathans@sgi.com
+
+# Pattern writing and checking
+pattern         ajones@sgi.com
+
+# dmapi based tests
+dmapi
+
+# filestreams based tests
+filestreams     dgc@sgi.com
+
+# case-insensitive based tests
+ci              bnaujok@sgi.com
+
+# test the mount/remount path
+mount           tes@sgi.com
+
+# test the NFS v4 ACL code if it exists
+nfs4acl         tes@sgi.com donaldd@sgi.com
+
+# test access time
+atime
+
+# Test preallocation calls
+prealloc
+
+# Test filesystem freeze
+freeze
+
+# Tests which may oops or hang
+dangerous
+
+# Old tests that we won't spend any effort trying to run and make work
+# on current systems
+deprecated
+
+#
+# test-group association ... one line per test
+#
+001 rw dir udf auto quick
+002 metadata udf auto quick
+003 db auto quick
+004 db auto quick
+005 dir udf auto quick
+006 dir udf auto quick
+007 dir udf auto quick
+008 rw ioctl auto quick
+009 rw ioctl auto prealloc quick
+010 other udf auto
+011 dir udf auto quick
+012 rw auto quick
+013 other ioctl udf auto quick
+014 rw udf auto quick
+015 other auto quick
+016 rw auto quick
+017 mount auto quick
+018 deprecated # log logprint v2log
+019 mkfs auto quick
+020 metadata attr udf auto quick
+021 db attr auto quick
+022 dump ioctl tape
+023 dump ioctl tape
+024 dump ioctl tape
+025 dump ioctl tape
+026 dump ioctl auto quick
+027 dump ioctl auto quick
+028 dump ioctl auto quick
+029 mkfs logprint log auto quick
+030 repair auto quick
+031 repair mkfs auto quick
+032 mkfs auto quick
+033 repair auto quick
+034 other auto quick
+035 dump ioctl tape auto
+036 dump ioctl remote tape
+037 dump ioctl remote tape
+038 dump ioctl remote tape
+039 dump ioctl remote tape
+040 other auto
+041 growfs ioctl auto
+042 fsr ioctl auto
+043 dump ioctl tape
+044 other auto
+045 other auto quick
+046 dump ioctl auto quick
+047 dump ioctl auto
+048 other auto quick
+049 rw auto quick
+050 quota auto quick
+051 acl udf auto quick
+052 quota db auto quick
+053 acl repair auto quick
+054 quota auto quick
+055 dump ioctl remote tape
+056 dump ioctl auto quick
+057 acl auto
+058 acl auto
+059 dump ioctl auto quick
+060 dump ioctl auto quick
+061 dump ioctl auto quick
+062 attr udf auto quick
+063 dump attr auto quick
+064 dump auto
+065 dump auto
+066 dump ioctl auto quick
+067 acl attr auto quick
+068 other auto freeze dangerous
+069 rw udf auto quick
+070 attr udf auto quick
+071 rw auto
+072 rw auto prealloc quick
+073 copy auto
+074 rw udf auto
+075 rw udf auto quick
+076 metadata rw udf auto quick
+077 acl attr auto enospc
+078 growfs auto quick
+079 acl attr ioctl metadata auto quick
+080 rw ioctl
+081 deprecated # log logprint quota
+082 deprecated # log logprint v2log
+083 rw auto
+084 ioctl rw auto
+085 log auto quick
+086 log v2log auto
+087 log v2log auto quota
+088 perms auto quick
+089 metadata auto
+090 rw auto
+091 rw auto quick
+092 other auto quick
+093 attr cap udf auto
+094 metadata dir ioctl auto
+095 log v2log auto
+096 mkfs v2log auto quick
+097 udf auto
+098 udf auto
+099 udf auto
+100 udf auto
+101 udf
+102 udf
+103 metadata dir ioctl auto quick
+104 growfs ioctl prealloc auto
+105 acl auto quick
+106 quota
+107 quota
+108 quota auto quick
+109 metadata auto
+110 repair auto
+111 ioctl
+112 rw aio auto quick
+113 rw aio auto quick
+114 parent attr
+115 parent attr
+116 quota auto quick
+117 attr auto quick
+118 quota auto quick
+119 log v2log auto freeze dangerous
+120 other auto quick
+121 log auto quick
+122 other auto quick
+123 perms auto quick
+124 pattern auto quick
+125 other auto
+126 perms auto quick
+127 rw auto
+128 perms auto quick
+129 rw auto quick
+130 pattern auto quick
+131 perms auto quick
+132 pattern auto
+133 rw auto
+134 quota auto quick
+135 metadata auto quick
+136 attr2
+137 metadata log auto
+138 metadata log auto
+139 metadata log auto
+140 metadata log auto
+141 rw auto quick
+142 dmapi auto
+143 dmapi auto
+144 dmapi auto
+145 dmapi auto
+146 dmapi auto
+147 dmapi auto
+148 repair auto
+149 repair auto
+150 dmapi auto
+151 dmapi auto
+152 dmapi auto
+153 dmapi auto
+154 dmapi auto
+155 dmapi auto
+156 dmapi auto
+157 dmapi auto
+158 dmapi auto
+159 dmapi auto
+160 dmapi auto
+161 dmapi auto
+162 dmapi auto
+163 dmapi auto
+164 rw pattern auto prealloc quick
+165 rw pattern auto prealloc quick
+166 rw metadata auto quick
+167 rw metadata auto
+168 dmapi auto
+169 rw metadata auto quick
+170 rw filestreams auto quick
+# the next three tests are not deterministic enough to get the
+# "right" result on all platforms/configuration, so don't run
+# them by default.
+171 rw filestreams
+172 rw filestreams
+173 rw filestreams
+174 rw filestreams auto
+175 dmapi auto
+176 dmapi auto
+177 rw other auto
+178 mkfs other auto
+179 metadata rw auto
+180 metadata rw auto
+181 log auto quick
+182 metadata rw auto
+183 rw other auto quick
+184 metadata auto quick
+185 dmapi auto
+186 attr auto quick
+187 attr auto quick
+188 ci dir auto
+189 mount auto quick
+190 rw auto quick
+191 nfs4acl auto
+192 atime auto
+193 metadata auto quick
+194 rw auto
+195 ioctl dump auto quick
+196 quota auto quick
+197 dir auto quick
+198 auto aio quick
+199 mount auto quick
+200 mount auto quick
+201 metadata auto quick
+202 repair auto quick
+203 ioctl auto
+204 metadata rw auto
+205 metadata rw auto
+206 growfs auto quick
+207 auto aio quick
+208 auto aio
+209 auto aio
+210 auto aio quick
+211 auto aio quick
+212 auto aio quick
+213 rw auto prealloc quick enospc
+214 rw auto prealloc quick
+215 auto metadata quick
+216 log metadata auto quick
+217 log metadata auto
+218 auto fsr quick
+219 auto quota quick
+220 auto quota quick
+221 auto metadata quick
+222 auto fsr ioctl quick
+223 auto quick
+224 auto
+225 auto quick
+226 auto enospc
+227 auto fsr
+228 rw auto prealloc quick
+229 auto rw
+230 auto quota quick
+231 auto quota
+232 auto quota
+233 auto quota
+234 auto quota
+235 auto quota quick
+236 auto quick metadata
+237 auto quick acl
+238 auto quick metadata ioctl
+239 auto aio rw
+240 auto aio quick rw
+241 auto
+242 auto quick prealloc
+243 auto quick prealloc
+244 auto quota quick
+245 auto quick dir
+246 auto quick rw
+247 auto quick rw
+248 auto quick rw
+249 auto quick rw 
+250 auto quick rw prealloc metadata
+251 ioctl trim
+252 auto quick prealloc
+253 auto quick
+254 auto quick
+255 auto quick prealloc
+256 auto quick
+257 dir auto quick
+258 auto quick
+259 auto quick
+260 auto quick trim
+261 auto quick quota
+262 auto quick quota
+263 rw auto quick
+264 auto
+265 auto
+266 dump ioctl auto quick
+267 dump ioctl tape
+268 dump ioctl tape
+269 auto rw prealloc ioctl enospc
+270 auto quota rw prealloc ioctl enospc
+271 auto rw quick
+272 auto enospc rw
+273 auto rw
+274 auto rw
+275 auto rw
+276 auto rw metadata
+277 auto ioctl quick metadata
+278 repair auto
+279 auto mkfs
+280 auto quota freeze dangerous
+281 dump ioctl auto quick
+282 dump ioctl auto quick
+283 dump ioctl auto quick
+284 auto
+285 auto rw
+286 other

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -1,0 +1,4 @@
+setup:
+ runargs : !mux
+  test_number: '001'
+  skip_dangerous: True 


### PR DESCRIPTION
Signed-off-by: praveen@linux.vnet.ibm.com
added xfstests Test case

```

v1: fetch xfstest suite from git (git://oss.sgi.com/xfs/cmds/xfstests)
v1: add README File (for requirement as well  test ) 
v1: run ./configure and make
v1: add test user 
v1: add function to list all test 
v1:add group file to run file system suite use group
v1: verify test run and inform user test run status
```
